### PR TITLE
#8: check if metaWorkspace is null

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -23,7 +23,7 @@ function _showHideWorkspaceBackground(workspaceBackground) {
 }
 
 function _animateFromOverview(windowPreview, animate) {
-    if (!windowPreview._workspace.metaWorkspace.active) {
+    if (windowPreview._workspace.metaWorkspace == null || !windowPreview._workspace.metaWorkspace.active) {
         return;
     }
     const toHide = [windowPreview._title, windowPreview._closeButton];


### PR DESCRIPTION
This fixes null exception when any window is on 2nd screen