### PR TITLE
Gnome 48 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and this comment below [Gnome Bugzilla - Window picker layout improvements](http
 | Gnome version   | Branch          | Is default branch? |
 |-----------------|-----------------|--------------------|
 | Gnome 40 to 44  |  [gnome-40-44](https://github.com/nlpsuge/Always-Show-Titles-In-Overview/tree/gnome-40-44)  | No  |
-| Gnome 45+       |  [gnome-45+](https://github.com/nlpsuge/Always-Show-Titles-In-Overview/tree/gnome-45+)      | Yes |
+| Gnome 45 to 48  |  [gnome-45+](https://github.com/nlpsuge/Always-Show-Titles-In-Overview/tree/gnome-45+)      | Yes |
 
 
 # Settings

--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,11 @@
   "name": "Always Show Titles In Overview",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47",
+    "48"
   ],
   "url": "https://github.com/nlpsuge/Always-Show-Titles-In-Overview",
   "uuid": "Always-Show-Titles-In-Overview@gmail.com",
-  "version": 26
+  "version": 27
 }

--- a/prefs.js
+++ b/prefs.js
@@ -2,7 +2,7 @@ import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 
-import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/shell/extensions/prefs.js';
 
 
 const DEFAULT_WINDOW_ACTIVE_SIZE_INC_RANGE = [5, 15, 25, 35, 45, 55, 60];


### PR DESCRIPTION
This pull request updates the project to support Gnome versions 47 and 48, corrects a file path case sensitivity issue, and updates the version number. Below are the key changes grouped by theme:

### Gnome Version Support:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37): Updated the version range for the Gnome 45+ branch to "Gnome 45 to 48" to reflect the expanded compatibility.
* [`metadata.json`](diffhunk://#diff-12e598daecade60b04e493f45c134fec9287ac7471114d95d1995b4fb651a6c8L7-R13): Added support for Gnome versions 47 and 48 in the `shell-version` array.

### Versioning:
* [`metadata.json`](diffhunk://#diff-12e598daecade60b04e493f45c134fec9287ac7471114d95d1995b4fb651a6c8L7-R13): Incremented the extension version from 26 to 27 to reflect the new updates.

### Bug Fix:
* [`prefs.js`](diffhunk://#diff-cbd3ad962010bb97aaa7d45e4a08400e6ee51212f9c9b3803aa7d6b513fe90b7L5-R5): Fixed a case sensitivity issue in the import path for `prefs.js` by changing `Extensions/js/extensions` to `extensions/prefs.js`. This resolves potential compatibility issues on case-sensitive file systems.