### PR TITLE
Update metadata.json for GNOME 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/nlpsuge/Always-Show-Titles-In-Overview",
   "uuid": "Always-Show-Titles-In-Overview@gmail.com",


### PR DESCRIPTION
Updating the `shell-version` array seems sufficient to support GNOME 49, as in my testing the extension works correctly on Fedora 43.

Closes #22