### PR TITLE
Fix typo: buttom → bottom

### DIFF
--- a/SettingsGtk4.ui
+++ b/SettingsGtk4.ui
@@ -147,7 +147,7 @@
                                 <child>
                                   <object class="GtkLabel" id="move_window_title_to_bottom_when_fullscreen_label">
                                     <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Move the window titles to the buttom when fullscreen</property>
+                                    <property name="label" translatable="yes">Move the window titles to the bottom when fullscreen</property>
                                     <property name="use-markup">1</property>
                                     <property name="xalign">0</property>
                                     <layout>
@@ -187,7 +187,7 @@
                                 <child>
                                   <object class="GtkLabel" id="move_window_title_to_bottom_for_video_player_label">
                                     <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Move the window titles to the buttom for video/TV players, like SMPlayer</property>
+                                    <property name="label" translatable="yes">Move the window titles to the bottom for video/TV players, like SMPlayer</property>
                                     <property name="xalign">0</property>
                                     <layout>
                                       <property name="column">0</property>


### PR DESCRIPTION
## Summary
- Fixed spelling of "bottom" in two UI labels in SettingsGtk4.ui

## Changes
- "Move the window titles to the buttom when fullscreen" → "Move the window titles to the bottom when fullscreen"
- "Move the window titles to the buttom for video/TV players, like SMPlayer" → "Move the window titles to the bottom for video/TV players, like SMPlayer"