### PR TITLE
Add title font size setting

### DIFF
--- a/SettingsGtk4.ui
+++ b/SettingsGtk4.ui
@@ -136,6 +136,44 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkListBoxRow" id="title_font_size_row">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkGrid" id="title_font_size_grid">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="column-spacing">32</property>
+                                <child>
+                                  <object class="GtkLabel" id="title_font_size_label">
+                                    <property name="use-markup">true</property>
+                                    <property name="label" translatable="yes">Title font size (0 = default)</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkScale" id="title_font_size_scale">
+                                    <property name="draw-value">1</property>
+                                    <property name="focusable">1</property>
+                                    <property name="valign">baseline</property>
+                                    <property name="hexpand">1</property>
+                                    <property name="round-digits">0</property>
+                                    <property name="digits">0</property>
+                                    <property name="value-pos">right</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkListBoxRow">
                             <property name="focusable">1</property>
                             <property name="child">
@@ -147,7 +185,7 @@
                                 <child>
                                   <object class="GtkLabel" id="move_window_title_to_bottom_when_fullscreen_label">
                                     <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Move the window titles to the buttom when fullscreen</property>
+                                    <property name="label" translatable="yes">Move the window titles to the bottom when fullscreen</property>
                                     <property name="use-markup">1</property>
                                     <property name="xalign">0</property>
                                     <layout>
@@ -187,7 +225,7 @@
                                 <child>
                                   <object class="GtkLabel" id="move_window_title_to_bottom_for_video_player_label">
                                     <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Move the window titles to the buttom for video/TV players, like SMPlayer</property>
+                                    <property name="label" translatable="yes">Move the window titles to the bottom for video/TV players, like SMPlayer</property>
                                     <property name="xalign">0</property>
                                     <layout>
                                       <property name="column">0</property>

--- a/extension.js
+++ b/extension.js
@@ -210,6 +210,12 @@ export default class AlwaysShowTitlesInOverviewExtension extends Extension {
 
             this._title.show();
 
+            // Apply custom font size if set
+            const fontSize = _settings.get_int('title-font-size');
+            if (fontSize > 0) {
+                this._title.set_style(`font-size: ${fontSize}pt;`);
+            }
+
             // titles
 
             // Remove title offset to avoid being covered by another window

--- a/prefs.js
+++ b/prefs.js
@@ -6,6 +6,7 @@ import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Ex
 
 
 const DEFAULT_WINDOW_ACTIVE_SIZE_INC_RANGE = [5, 15, 25, 35, 45, 55, 60];
+const DEFAULT_TITLE_FONT_SIZE_RANGE = [0, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32];
 
 const Settings = GObject.registerClass({
     GTypeName: 'AlwaysShowTitlesInOverviewSettings',
@@ -82,6 +83,12 @@ const Settings = GObject.registerClass({
             this.window_active_size_inc_scale.set_value(window_active_size_inc_scale);
         });
 
+        // Listen changes of title-font-size, pass the changed value to GtkScale
+        this._settings.connect('changed::title-font-size', (settings) => {
+            const title_font_size = settings.get_int('title-font-size');
+            this.title_font_size_scale.set_value(title_font_size);
+        });
+
         this._settings.bind(
             'hide-background',
             this.hide_background_switch,
@@ -106,6 +113,27 @@ const Settings = GObject.registerClass({
         });
 
         this._renderWindowTitlePosition();
+
+        // Title font size slider
+        this.title_font_size_scale = this._builder.get_object('title_font_size_scale');
+        this.title_font_size_scale.set_format_value_func((scale, value) => {
+            return value === 0 ? 'default' : value + ' pt';
+        });
+
+        let fontMin = DEFAULT_TITLE_FONT_SIZE_RANGE[0];
+        let fontMax = DEFAULT_TITLE_FONT_SIZE_RANGE[DEFAULT_TITLE_FONT_SIZE_RANGE.length - 1];
+        this.title_font_size_scale.set_range(fontMin, fontMax);
+        this.title_font_size_scale.set_value(
+            this._settings.get_int('title-font-size'));
+        DEFAULT_TITLE_FONT_SIZE_RANGE.slice().forEach(num => {
+            this.title_font_size_scale.add_mark(num, Gtk.PositionType.TOP, null);
+        });
+
+        // Listen changes of title_font_size_scale, pass the changed value to Gio.Gsettings
+        this.title_font_size_scale.connect('value-changed', (scale) => {
+            const value = scale.get_value();
+            this._settings.set_int('title-font-size', value);
+        });
 
         this.move_window_title_to_bottom_when_fullscreen_switch = this._builder.get_object('move_window_title_to_bottom_when_fullscreen_switch');
         this.move_window_title_to_bottom_when_fullscreen_switch.connect('notify::active', (widget) => {

--- a/schemas/org.gnome.shell.extensions.always-show-titles-in-overview.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.always-show-titles-in-overview.gschema.xml
@@ -86,5 +86,14 @@
       Whether hide the background in the Overview or not.
       </description>
     </key>
+    <key name="title-font-size" type="i">
+      <default>0</default>
+      <summary>Window title font size in points (0 = use default)</summary>
+      <description>
+      Custom font size for window titles in the Overview.
+      Set to 0 to use the default system font size.
+      Recommended range: 10-24.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
## Summary
Adds a new setting to customize the font size of window titles in the Overview.

## Changes
- New schema key: `title-font-size` (integer, default 0 = system default)
- Slider in preferences UI (range 0-32pt)
- Applied via inline style on the title widget

## Use case
This allows users to increase readability of window titles, especially on high-resolution displays or for accessibility needs.

## Screenshot
The new slider appears in the "Window title" section of the preferences, below the position buttons.