### PR TITLE
Fix DesktopAppInfo category lookup with newer GLib

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,6 +31,7 @@ let customWorkspace;
 let _objectPrototype; 
 let windowTracker;
 let _idleId;
+let GioUnix = null;
 
 let allUpdateWindowPreviewFlagMask = 0;
 const updateWindowPreviewFlags = {
@@ -55,6 +56,13 @@ function _initializeObject(extensionObject) {
     _objectPrototype = new ObjectPrototype.ObjectPrototype();
 
     windowTracker = Shell.WindowTracker.get_default();
+
+    try {
+        GioUnix = imports.gi.GioUnix;
+    } catch {
+        // GioUnix-2.0 is not separately available on older supported GLib.
+        GioUnix = null;
+    }
 }
 
 function _hideOrMove(windowPreview, flags) {
@@ -70,11 +78,14 @@ function _hideOrMove(windowPreview, flags) {
     if (flags & (updateWindowPreviewFlags.ICON_SHOW_OR_HIDE_FOR_VIDEO_PLAYER 
                 | updateWindowPreviewFlags.TITLE_MOVE_TO_BOTTOM_FOR_VIDEO_PLAYER)) {
         const app = windowTracker.get_window_app(windowPreview.metaWindow);
-        const app_info = app?.get_app_info();
-        // app_info can be null if backed by a window (there's no .desktop file association)
+        const appId = app?.get_id();
+        // desktopInfo can be null if backed by a window (there's no .desktop file association)
         // See: shell_app_is_window_backed()
+        const desktopInfo = appId && GioUnix
+            ? GioUnix.DesktopAppInfo.new(appId)
+            : app?.get_app_info();
         let recheck = false;
-        const categories = app_info?.get_categories();
+        const categories = desktopInfo?.get_categories();
         if (categories) {
             const categoriesArr = categories.split(';')
             for (const category of categoriesArr) {
@@ -95,8 +106,8 @@ function _hideOrMove(windowPreview, flags) {
         }
 
         if (recheck) {
-            log('Rechecking whether ' + app_info?.get_name() + ' is a video player or not by checking mime type');
-            const supported_types = app_info?.get_supported_types();
+            log('Rechecking whether ' + desktopInfo?.get_name() + ' is a video player or not by checking mime type');
+            const supported_types = desktopInfo?.get_supported_types();
             if (supported_types) {
                 for (const supported_type of supported_types) {
                     // Support Video
@@ -366,6 +377,8 @@ export default class AlwaysShowTitlesInOverviewExtension extends Extension {
             GLib.source_remove(_idleId);
             _idleId = null;
         }
+
+        GioUnix = null;
 
     }
 }


### PR DESCRIPTION
## Summary

Fixes the GNOME Shell 48.7 Overview exception:

`TypeError: app_info.get_categories is not a function`

`Shell.App.get_app_info()` returns the generic `Gio.AppInfo` wrapper, which can no longer be assumed to expose the UNIX-specific `get_categories()` method on newer GLib/GObject-introspection releases.

When the separately importable `GioUnix` namespace is available, the extension now creates `GioUnix.DesktopAppInfo` from the Shell app desktop ID before reading categories. The lookup is guarded at runtime: older GLib releases without `GioUnix-2.0` retain the existing `get_app_info()` path, so the extension does not fail to load on GNOME 45-era systems. Window-backed apps with no desktop ID still produce no desktop info and are skipped as before.

The issue was reproduced on GNOME Shell 48.7.

## Validation

- Searched all extension sources for `get_categories`, `DesktopAppInfo`, `GioUnix`, and `get_app_info`; this is the only category lookup.
- Ran `node --check extension.js` successfully.
- Verified the old fallback with GJS and GLib 2.74: `GioUnix-2.0` is unavailable while `Gio.DesktopAppInfo` remains available.
- Ran `git diff --check` and reviewed the focused final diff.
- Ran `gjs -m extension.js`; parsing advanced to GNOME Shell resource-module resolution, which cannot complete outside a running GNOME Shell session.